### PR TITLE
Update RegistrationConfirmedAction.php

### DIFF
--- a/src/Action/RegistrationConfirmedAction.php
+++ b/src/Action/RegistrationConfirmedAction.php
@@ -58,11 +58,11 @@ final class RegistrationConfirmedAction
     {
         $token = $this->tokenStorage->getToken();
 
-        if (null === $token || !\is_callable([$token, 'getProviderKey'])) {
+        if (null === $token || !\is_callable([$token, 'getFirewallName'])) {
             return null;
         }
 
-        $key = sprintf('_security.%s.target_path', $token->getProviderKey());
+        $key = sprintf('_security.%s.target_path', $token->getFirewallName());
 
         if ($session->has($key)) {
             return $session->get($key);


### PR DESCRIPTION
Since symfony/security-core 5.2: Method "Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken::getProviderKey" is deprecated, use "getFirewallName()" instead.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #480

## Subject

<!-- Describe your Pull Request content here -->
